### PR TITLE
Listen all hosts

### DIFF
--- a/server/src/main/java/com/salesforce/bazel/maven/proxy/server/MavenProxyServer.java
+++ b/server/src/main/java/com/salesforce/bazel/maven/proxy/server/MavenProxyServer.java
@@ -118,7 +118,7 @@ public class MavenProxyServer implements Callable<Void> {
 			LOG.warn("Configuring unsecure communication on port {}.", unsecurePort);
 			ServerConnector connector = new ServerConnector(server);
 			connector.setPort(unsecurePort);
-			connector.setHost("127.0.0.1");
+			connector.setHost("0.0.0.0");
 			server.addConnector(connector);
 		}
 


### PR DESCRIPTION
when we are trying to port-forward to container we should make our service to listen to everything, not only localhost.